### PR TITLE
Add clientes listing page

### DIFF
--- a/src/app/clientes/layout.tsx
+++ b/src/app/clientes/layout.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Link from 'next/link';
+
+export default function ClientesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex">
+      <aside className="w-64 bg-gray-100 p-4 space-y-2">
+        <nav className="flex flex-col gap-2">
+          <Link href="/" className="text-gray-700 hover:underline">Home</Link>
+          <Link href="/clientes" className="text-gray-700 hover:underline">Clientes</Link>
+        </nav>
+      </aside>
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/clientes/page.tsx
+++ b/src/app/clientes/page.tsx
@@ -1,0 +1,28 @@
+export default function ClientesPage() {
+  const clientes = [
+    { id: 1, nome: 'Jo\u00e3o da Silva', email: 'joao@example.com' },
+    { id: 2, nome: 'Maria Santos', email: 'maria@example.com' },
+  ];
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold">Clientes</h1>
+        <button className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Adicionar Cliente</button>
+      </div>
+      <input
+        type="text"
+        placeholder="Buscar cliente"
+        className="border rounded w-full p-2 mb-4"
+      />
+      <ul className="bg-white shadow rounded divide-y">
+        {clientes.map((cliente) => (
+          <li key={cliente.id} className="p-4">
+            <p className="font-medium">{cliente.nome}</p>
+            <p className="text-sm text-gray-500">{cliente.email}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,10 @@
+import { join } from 'path';
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [join(__dirname, 'src/**/*.{ts,tsx}')],
+  theme: { extend: {} },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- implement `/clientes` page with static clients list
- add sidebar navigation layout
- configure Tailwind CSS

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68542e0b56a88320b308ec206bd48441