### PR TITLE
Infer production API base URL from host

### DIFF
--- a/src/shared/services/axios.ts
+++ b/src/shared/services/axios.ts
@@ -12,7 +12,13 @@ import {
 } from '../../modules/auth/utils/authCache'
 import type { RefreshTokenResponse } from '../../modules/auth/types/user'
 
-const baseURL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'
+const inferredProductionBaseURL =
+  typeof window !== 'undefined' && window.location.hostname.endsWith('go-mech.com')
+    ? `${window.location.protocol}//api.go-mech.com`
+    : undefined
+
+const baseURL =
+  import.meta.env.VITE_API_BASE_URL ?? inferredProductionBaseURL ?? 'http://localhost:8080'
 
 const api = axios.create({
   baseURL,


### PR DESCRIPTION
## Summary
- infer a production API fallback URL based on the deployed host name
- keep the existing environment-variable and local-development defaults intact

## Testing
- yarn lint *(fails: workspace not present in lockfile in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_690903c66e648331b29cc177159f3e92