### PR TITLE
feat: integrate frontend inventory, audit, and analytics modules

### DIFF
--- a/src/modules/admin/components/AnalyticsPanel.tsx
+++ b/src/modules/admin/components/AnalyticsPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 
 import { analyticsApi } from "../../analytics/services/api";
-import type { AnalyticsResponse } from "../../analytics/types/analytics";
+import type { AnalyticsRequest, AnalyticsResponse } from "../../analytics/types/analytics";
 
 export default function AnalyticsPanel() {
   const defaultPayloadExample = '{\n  "range": "30d"\n}';
@@ -11,10 +11,10 @@ export default function AnalyticsPanel() {
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<AnalyticsResponse | null>(null);
 
-  const mutation = useMutation({
+  const mutation = useMutation<AnalyticsResponse, unknown, AnalyticsRequest>({
     mutationFn: analyticsApi.send,
     onSuccess: response => {
-      setResult(response.data);
+      setResult(response);
     },
   });
 

--- a/src/modules/admin/components/AuditPanel.tsx
+++ b/src/modules/admin/components/AuditPanel.tsx
@@ -2,38 +2,96 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 
 import { auditApi } from "../../audit/services/api";
-import type { AuditEventResponse } from "../../audit/types/audit";
+import type { AuditEventRequest, AuditEventResponse, AuditModule } from "../../audit/types/audit";
+
+const auditModules: Array<{ value: AuditModule; label: string }> = [
+  { value: "INVENTORY", label: "Estoque" },
+  { value: "SERVICE_ORDER", label: "Ordem de serviço" },
+  { value: "CUSTOMER", label: "Cliente" },
+  { value: "OPERATIONS", label: "Operações" },
+  { value: "SUPPLIER", label: "Fornecedor" },
+  { value: "ANALYTICS", label: "Analytics" },
+  { value: "AUDIT", label: "Auditoria" },
+];
+
+const auditEventTypes = [
+  "OS_APPROVAL",
+  "PART_RESERVATION",
+  "STOCK_ADJUSTMENT",
+  "USER_SESSION",
+  "DASHBOARD_EXPORT",
+];
+
+const auditOperations = ["CREATE", "UPDATE", "DELETE", "APPROVE", "EXPORT"];
+
+const defaultMetadataExample = '{\n  "approvedBy": "admin@go-mech.com"\n}';
+
+function formatDateTimeLocalInput(date: Date) {
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(
+    date.getMinutes(),
+  )}`;
+}
+
+function toISOString(value: string): string | null {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
 
 export default function AuditPanel() {
-  const defaultMetadataExample = '{\n  "approvedBy": "admin@go-mech.com"\n}';
-  const [action, setAction] = useState("OS_APPROVAL");
-  const [referenceId, setReferenceId] = useState("");
   const [metadataText, setMetadataText] = useState(defaultMetadataExample);
-  const [error, setError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
   const [lastEvent, setLastEvent] = useState<AuditEventResponse | null>(null);
+  const [formState, setFormState] = useState({
+    eventType: auditEventTypes[0] ?? "OS_APPROVAL",
+    operation: auditOperations[0] ?? "CREATE",
+    module: auditModules[0]?.value ?? "INVENTORY",
+    username: "",
+    role: "ADMIN",
+    occurredAt: formatDateTimeLocalInput(new Date()),
+    referenceId: "",
+  });
 
-  const mutation = useMutation({
+  const mutation = useMutation<AuditEventResponse, unknown, AuditEventRequest>({
     mutationFn: auditApi.createEvent,
-    onSuccess: response => {
-      setLastEvent(response.data);
+    onSuccess: data => {
+      setLastEvent(data);
     },
   });
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    setError(null);
+    setFormError(null);
     setLastEvent(null);
 
-    if (!action.trim()) {
-      setError("Descreva a ação auditável");
+    if (!formState.eventType.trim() || !formState.operation.trim() || !formState.username.trim()) {
+      setFormError("Preencha tipo, operação e usuário responsáveis pelo evento");
+      return;
+    }
+
+    const occurredAtIso = toISOString(formState.occurredAt);
+    if (!occurredAtIso) {
+      setFormError("Informe uma data/hora válida");
       return;
     }
 
     try {
-      const metadata = metadataText.trim() ? JSON.parse(metadataText) : undefined;
-      mutation.mutate({ action: action.trim(), referenceId: referenceId.trim() || undefined, metadata });
+      const metadata = metadataText.trim() ? (JSON.parse(metadataText) as Record<string, unknown>) : undefined;
+      mutation.mutate({
+        eventType: formState.eventType.trim(),
+        operation: formState.operation.trim(),
+        module: formState.module,
+        username: formState.username.trim(),
+        role: formState.role.trim(),
+        occurredAt: occurredAtIso,
+        referenceId: formState.referenceId.trim() || undefined,
+        metadata,
+      });
     } catch (parseError) {
-      setError("Metadados inválidos. Informe um JSON válido.");
+      setFormError("Metadados inválidos. Informe um JSON válido.");
     }
   };
 
@@ -41,34 +99,97 @@ export default function AuditPanel() {
     <div className="space-y-6">
       <header className="rounded-lg border border-gray-200 bg-white p-4 sm:p-6 shadow-sm">
         <h2 className="text-xl sm:text-2xl font-bold text-orangeWheel-500">Registro de Auditoria</h2>
-        <p className="mt-2 text-xs sm:text-sm text-gray-500">Documente ações críticas com registro imutável em blockchain.</p>
+        <p className="mt-2 text-xs sm:text-sm text-gray-500">
+          Documente ações críticas com registro imutável em blockchain.
+        </p>
       </header>
 
       <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 bg-white p-4 sm:p-6 shadow-sm">
-        {error && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+        {formError && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{formError}</p>}
         <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label className="text-sm font-medium text-gray-700">Ação</label>
-            <input
-              value={action}
-              onChange={event => setAction(event.target.value)}
-              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
-              placeholder="ex: OS_APPROVAL"
-              required
-            />
+          <div className="flex flex-col text-sm">
+            <label className="text-xs font-semibold text-gray-600">Tipo do evento</label>
+            <select
+              value={formState.eventType}
+              onChange={event => setFormState(prev => ({ ...prev, eventType: event.target.value }))}
+              className="mt-1 rounded-lg border border-gray-300 px-3 py-2 focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+            >
+              {auditEventTypes.map(type => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
           </div>
-          <div>
-            <label className="text-sm font-medium text-gray-700">Referência</label>
+          <div className="flex flex-col text-sm">
+            <label className="text-xs font-semibold text-gray-600">Operação</label>
+            <select
+              value={formState.operation}
+              onChange={event => setFormState(prev => ({ ...prev, operation: event.target.value }))}
+              className="mt-1 rounded-lg border border-gray-300 px-3 py-2 focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+            >
+              {auditOperations.map(operation => (
+                <option key={operation} value={operation}>
+                  {operation}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col text-sm">
+            <label className="text-xs font-semibold text-gray-600">Módulo</label>
+            <select
+              value={formState.module}
+              onChange={event => setFormState(prev => ({ ...prev, module: event.target.value as AuditModule }))}
+              className="mt-1 rounded-lg border border-gray-300 px-3 py-2 focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+            >
+              {auditModules.map(module => (
+                <option key={module.value} value={module.value}>
+                  {module.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col text-sm">
+            <label className="text-xs font-semibold text-gray-600">Referência</label>
             <input
-              value={referenceId}
-              onChange={event => setReferenceId(event.target.value)}
-              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+              value={formState.referenceId}
+              onChange={event => setFormState(prev => ({ ...prev, referenceId: event.target.value }))}
+              className="mt-1 rounded-lg border border-gray-300 px-3 py-2 focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
               placeholder="ID da OS, cliente, etc."
             />
           </div>
+          <div className="flex flex-col text-sm">
+            <label className="text-xs font-semibold text-gray-600">Usuário responsável</label>
+            <input
+              value={formState.username}
+              onChange={event => setFormState(prev => ({ ...prev, username: event.target.value }))}
+              className="mt-1 rounded-lg border border-gray-300 px-3 py-2 focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+              placeholder="usuario@go-mech.com"
+              required
+            />
+          </div>
+          <div className="flex flex-col text-sm">
+            <label className="text-xs font-semibold text-gray-600">Papel</label>
+            <input
+              value={formState.role}
+              onChange={event => setFormState(prev => ({ ...prev, role: event.target.value }))}
+              className="mt-1 rounded-lg border border-gray-300 px-3 py-2 focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+              placeholder="ADMIN"
+            />
+          </div>
+          <div className="flex flex-col text-sm">
+            <label className="text-xs font-semibold text-gray-600">Data/hora da ocorrência</label>
+            <input
+              type="datetime-local"
+              value={formState.occurredAt}
+              onChange={event => setFormState(prev => ({ ...prev, occurredAt: event.target.value }))}
+              className="mt-1 rounded-lg border border-gray-300 px-3 py-2 focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+              required
+            />
+          </div>
         </div>
-        <div>
-          <label className="text-sm font-medium text-gray-700">Metadados adicionais (JSON)</label>
+        <div className="flex flex-col text-sm">
+          <label className="text-xs font-semibold text-gray-600">Metadados adicionais (JSON)</label>
           <textarea
             rows={6}
             value={metadataText}
@@ -93,7 +214,7 @@ export default function AuditPanel() {
         </button>
       </form>
 
-      {mutation.isError && !error && (
+      {mutation.isError && !formError && (
         <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
           {(mutation.error as any)?.response?.data?.message ?? "Não foi possível registrar o evento."}
         </div>
@@ -111,7 +232,24 @@ export default function AuditPanel() {
             )}
           </div>
           <div className="rounded-md border border-gray-100 bg-gray-50 p-3 text-sm text-gray-700">
-            <p>Ação: <span className="font-semibold">{lastEvent.action}</span></p>
+            <p>
+              Tipo: <span className="font-semibold">{lastEvent.eventType}</span>
+            </p>
+            <p>
+              Operação: <span className="font-semibold">{lastEvent.operation}</span>
+            </p>
+            <p>
+              Módulo: <span className="font-semibold">{lastEvent.module}</span>
+            </p>
+            <p>
+              Usuário: <span className="font-semibold">{lastEvent.username}</span>
+            </p>
+            <p>
+              Papel: <span className="font-semibold">{lastEvent.role}</span>
+            </p>
+            <p>
+              Ocorrência: {new Date(lastEvent.occurredAt).toLocaleString("pt-BR")}
+            </p>
             {lastEvent.referenceId && <p>Referência: {lastEvent.referenceId}</p>}
             {lastEvent.blockchainHash && <p>Hash: {lastEvent.blockchainHash}</p>}
           </div>
@@ -125,4 +263,3 @@ export default function AuditPanel() {
     </div>
   );
 }
-

--- a/src/modules/analytics/services/api.ts
+++ b/src/modules/analytics/services/api.ts
@@ -1,6 +1,13 @@
 import api from "../../../shared/services/axios";
-import type { AnalyticsRequest, AnalyticsResponse } from "../types/analytics";
+import type { AnalyticsInsight, AnalyticsRequest, AnalyticsResponse } from "../types/analytics";
 
 export const analyticsApi = {
-  send: (payload: AnalyticsRequest) => api.post<AnalyticsResponse>("/analytics", payload),
+  send: async (payload: AnalyticsRequest): Promise<AnalyticsResponse> => {
+    const response = await api.post<AnalyticsResponse>("/analytics", payload);
+    return response.data;
+  },
+  getInsights: async (): Promise<AnalyticsInsight[]> => {
+    const response = await api.get<AnalyticsInsight[]>("/analytics/insights");
+    return response.data;
+  },
 };

--- a/src/modules/analytics/types/analytics.ts
+++ b/src/modules/analytics/types/analytics.ts
@@ -4,8 +4,19 @@ export interface AnalyticsRequest {
 }
 
 export interface AnalyticsResponse {
-  status: string
+  status: 'SUCCESS' | 'ERROR'
   data?: unknown
   message?: string
   generatedAt?: string
+}
+
+export type AnalyticsInsightCategory = 'INVENTORY' | 'CUSTOMER' | 'OPERATIONS' | 'SUPPLIER'
+
+export interface AnalyticsInsight {
+  id: string
+  title: string
+  description: string
+  category: AnalyticsInsightCategory
+  createdAt?: string
+  updatedAt?: string
 }

--- a/src/modules/audit/components/AuditEventPage.tsx
+++ b/src/modules/audit/components/AuditEventPage.tsx
@@ -418,22 +418,27 @@ function AuditEventContent() {
                       <div className="text-[10px] uppercase text-gray-400">{event.role}</div>
                     </td>
                     <td className="px-3 py-3 text-xs text-gray-600">
-                      {event.blockchainHash ? (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            if (navigator?.clipboard?.writeText) {
-                              void navigator.clipboard.writeText(event.blockchainHash);
-                            }
-                          }}
-                          className="break-all text-left font-mono text-[11px] text-orangeWheel-600 hover:underline"
-                          title="Clique para copiar"
-                        >
-                          {event.blockchainHash}
-                        </button>
-                      ) : (
-                        <span className="text-gray-400">—</span>
-                      )}
+                      {(() => {
+                        const hash = event.blockchainHash ?? "";
+                        if (!hash) {
+                          return <span className="text-gray-400">—</span>;
+                        }
+
+                        return (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (navigator?.clipboard?.writeText) {
+                                void navigator.clipboard.writeText(hash);
+                              }
+                            }}
+                            className="break-all text-left font-mono text-[11px] text-orangeWheel-600 hover:underline"
+                            title="Clique para copiar"
+                          >
+                            {hash}
+                          </button>
+                        );
+                      })()}
                       {event.previousHash && (
                         <div className="mt-1 text-[10px] text-gray-400">Prev: {event.previousHash}</div>
                       )}

--- a/src/modules/audit/components/AuditEventPage.tsx
+++ b/src/modules/audit/components/AuditEventPage.tsx
@@ -1,10 +1,51 @@
-import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 import ProtectedRoute from "../../auth/components/ProtectedRoute";
 import RoleGuard from "../../auth/components/RoleGuard";
+import { useAuth } from "../../auth/hooks/useAuth";
 import { auditApi } from "../services/api";
-import type { AuditEventResponse } from "../types/audit";
+import type { AuditEventFilters, AuditEventResponse, AuditModule } from "../types/audit";
+
+const auditModules: Array<{ value: AuditModule; label: string }> = [
+  { value: "INVENTORY", label: "Estoque" },
+  { value: "SERVICE_ORDER", label: "Ordem de serviço" },
+  { value: "CUSTOMER", label: "Cliente" },
+  { value: "OPERATIONS", label: "Operações" },
+  { value: "SUPPLIER", label: "Fornecedor" },
+  { value: "ANALYTICS", label: "Analytics" },
+  { value: "AUDIT", label: "Auditoria" },
+];
+
+const auditEventTypes = [
+  "OS_APPROVAL",
+  "PART_RESERVATION",
+  "STOCK_ADJUSTMENT",
+  "USER_SESSION",
+  "DASHBOARD_EXPORT",
+];
+
+const auditOperations = ["CREATE", "UPDATE", "DELETE", "APPROVE", "EXPORT"];
+
+const metadataExample = `{
+  "approvedBy": "admin@go-mech.com",
+  "context": "Checklist concluído"
+}`;
+
+function formatDateTimeLocalInput(date: Date) {
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(
+    date.getMinutes(),
+  )}`;
+}
+
+function toISOString(value: string): string | null {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
 
 export default function AuditEventPage() {
   return (
@@ -17,68 +58,226 @@ export default function AuditEventPage() {
 }
 
 function AuditEventContent() {
-  const defaultMetadataExample = '{\n  "approvedBy": "admin@go-mech.com"\n}';
-  const [action, setAction] = useState("OS_APPROVAL");
-  const [referenceId, setReferenceId] = useState("");
-  const [metadataText, setMetadataText] = useState(defaultMetadataExample);
-  const [error, setError] = useState<string | null>(null);
+  const { data: auth } = useAuth();
+  const [metadataText, setMetadataText] = useState(metadataExample);
+  const [formError, setFormError] = useState<string | null>(null);
   const [lastEvent, setLastEvent] = useState<AuditEventResponse | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sortField, setSortField] = useState<"occurredAt" | "module" | "eventType" | "username">("occurredAt");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
+
+  const [formState, setFormState] = useState({
+    eventType: auditEventTypes[0] ?? "OS_APPROVAL",
+    operation: auditOperations[0] ?? "CREATE",
+    module: auditModules[0]?.value ?? "INVENTORY",
+    username: auth?.email ?? auth?.name ?? "",
+    role: auth?.role ?? "ADMIN",
+    occurredAt: formatDateTimeLocalInput(new Date()),
+    referenceId: "",
+  });
+
+  const [filters, setFilters] = useState<AuditEventFilters>({
+    page: 0,
+    size: 10,
+    sort: "occurredAt,DESC",
+    module: undefined,
+    eventType: undefined,
+  });
+
+  const eventsQuery = useQuery({
+    queryKey: ["audit", "events", filters],
+    queryFn: () => auditApi.listEvents(filters),
+  });
+
+  const events = eventsQuery.data?.content ?? [];
+
+  const filteredEvents = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    if (!term) {
+      return events;
+    }
+
+    return events.filter(event =>
+      [
+        event.eventType,
+        event.operation,
+        event.module,
+        event.username,
+        event.referenceId,
+        event.blockchainHash,
+        event.previousHash,
+      ]
+        .filter(Boolean)
+        .some(value => value!.toLowerCase().includes(term)),
+    );
+  }, [events, searchTerm]);
+
+  const sortedEvents = useMemo(() => {
+    const directionMultiplier = sortDirection === "asc" ? 1 : -1;
+    return [...filteredEvents].sort((a, b) => {
+      if (sortField === "occurredAt") {
+        return (
+          (new Date(a.occurredAt).getTime() - new Date(b.occurredAt).getTime()) * directionMultiplier * -1
+        );
+      }
+
+      const aValue = (a[sortField] ?? "").toString().toLowerCase();
+      const bValue = (b[sortField] ?? "").toString().toLowerCase();
+      if (aValue === bValue) {
+        return 0;
+      }
+      return aValue > bValue ? directionMultiplier : -directionMultiplier;
+    });
+  }, [filteredEvents, sortField, sortDirection]);
 
   const mutation = useMutation({
     mutationFn: auditApi.createEvent,
-    onSuccess: response => {
-      setLastEvent(response.data);
+    onSuccess: data => {
+      setLastEvent(data);
+      void eventsQuery.refetch();
     },
   });
 
+  const totalPages = eventsQuery.data?.totalPages ?? 0;
+  const currentPage = eventsQuery.data?.number ?? 0;
+
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    setError(null);
+    setFormError(null);
     setLastEvent(null);
 
-    if (!action.trim()) {
-      setError("Descreva a ação auditável");
+    if (!formState.eventType.trim() || !formState.operation.trim() || !formState.username.trim()) {
+      setFormError("Preencha tipo, operação e usuário responsáveis pelo evento");
+      return;
+    }
+
+    const occurredAtIso = toISOString(formState.occurredAt);
+    if (!occurredAtIso) {
+      setFormError("Informe uma data/hora válida");
       return;
     }
 
     try {
-      const metadata = metadataText.trim() ? JSON.parse(metadataText) : undefined;
-      mutation.mutate({ action: action.trim(), referenceId: referenceId.trim() || undefined, metadata });
+      const metadata = metadataText.trim() ? (JSON.parse(metadataText) as Record<string, unknown>) : undefined;
+      mutation.mutate({
+        eventType: formState.eventType.trim(),
+        operation: formState.operation.trim(),
+        module: formState.module,
+        username: formState.username.trim(),
+        role: formState.role,
+        occurredAt: occurredAtIso,
+        referenceId: formState.referenceId.trim() || undefined,
+        metadata,
+      });
     } catch (parseError) {
-      setError("Metadados inválidos. Informe um JSON válido.");
+      setFormError("Metadados inválidos. Informe um JSON válido.");
     }
   };
 
   return (
     <div className="space-y-6">
       <header className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-        <h1 className="text-2xl font-bold text-orangeWheel-500">Registro de Auditoria</h1>
-        <p className="mt-2 text-sm text-gray-500">Documente ações críticas com registro imutável em blockchain.</p>
+        <h1 className="text-2xl font-bold text-orangeWheel-500">Auditoria &amp; Trilhas de Acesso</h1>
+        <p className="mt-2 text-sm text-gray-500">
+          Registre manualmente operações críticas e acompanhe os eventos consolidados com assinatura blockchain.
+        </p>
       </header>
 
       <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-        {error && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+        {formError && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{formError}</p>}
+        <div className="grid gap-4 md:grid-cols-3">
+          <div>
+            <label className="text-sm font-medium text-gray-700">Tipo de evento</label>
+            <input
+              list="audit-event-types"
+              value={formState.eventType}
+              onChange={event => setFormState(prev => ({ ...prev, eventType: event.target.value }))}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+              placeholder="Ex: OS_APPROVAL"
+              required
+            />
+            <datalist id="audit-event-types">
+              {auditEventTypes.map(option => (
+                <option key={option} value={option} />
+              ))}
+            </datalist>
+          </div>
+          <div>
+            <label className="text-sm font-medium text-gray-700">Operação</label>
+            <select
+              value={formState.operation}
+              onChange={event => setFormState(prev => ({ ...prev, operation: event.target.value }))}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+            >
+              {auditOperations.map(operation => (
+                <option key={operation} value={operation}>
+                  {operation}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-sm font-medium text-gray-700">Módulo</label>
+            <select
+              value={formState.module}
+              onChange={event => setFormState(prev => ({ ...prev, module: event.target.value as AuditModule }))}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+            >
+              {auditModules.map(module => (
+                <option key={module.value} value={module.value}>
+                  {module.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
         <div className="grid gap-4 md:grid-cols-2">
           <div>
-            <label className="text-sm font-medium text-gray-700">Ação</label>
+            <label className="text-sm font-medium text-gray-700">Usuário responsável</label>
             <input
-              value={action}
-              onChange={event => setAction(event.target.value)}
+              value={formState.username}
+              onChange={event => setFormState(prev => ({ ...prev, username: event.target.value }))}
               className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
-              placeholder="ex: OS_APPROVAL"
+              placeholder="usuario@go-mech.com"
               required
             />
           </div>
           <div>
-            <label className="text-sm font-medium text-gray-700">Referência</label>
-            <input
-              value={referenceId}
-              onChange={event => setReferenceId(event.target.value)}
+            <label className="text-sm font-medium text-gray-700">Perfil</label>
+            <select
+              value={formState.role}
+              onChange={event => setFormState(prev => ({ ...prev, role: event.target.value as typeof formState.role }))}
               className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
-              placeholder="ID da OS, cliente, etc."
+            >
+              <option value="ADMIN">ADMIN</option>
+              <option value="USER">USER</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="text-sm font-medium text-gray-700">Referência (opcional)</label>
+            <input
+              value={formState.referenceId}
+              onChange={event => setFormState(prev => ({ ...prev, referenceId: event.target.value }))}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+              placeholder="Código da OS, cliente, etc."
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium text-gray-700">Data e hora da ocorrência</label>
+            <input
+              type="datetime-local"
+              value={formState.occurredAt}
+              onChange={event => setFormState(prev => ({ ...prev, occurredAt: event.target.value }))}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+              required
             />
           </div>
         </div>
+
         <div>
           <label className="text-sm font-medium text-gray-700">Metadados adicionais (JSON)</label>
           <textarea
@@ -86,9 +285,10 @@ function AuditEventContent() {
             value={metadataText}
             onChange={event => setMetadataText(event.target.value)}
             className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 font-mono text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
-            placeholder={defaultMetadataExample}
+            placeholder={metadataExample}
           />
         </div>
+
         <button
           type="submit"
           disabled={mutation.isPending}
@@ -105,35 +305,231 @@ function AuditEventContent() {
         </button>
       </form>
 
-      {mutation.isError && !error && (
+      {mutation.isError && !formError && (
         <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
           {(mutation.error as any)?.response?.data?.message ?? "Não foi possível registrar o evento."}
         </div>
       )}
 
-      {lastEvent && (
-        <section className="space-y-3 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-lg font-semibold text-gray-800">Evento registrado</h2>
-              <p className="text-xs text-gray-500">{new Date(lastEvent.createdAt).toLocaleString("pt-BR")}</p>
+      {lastEvent && <AuditEventPreview event={lastEvent} />}
+
+      <section className="space-y-4 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="flex flex-col text-sm">
+              <label className="text-xs font-semibold text-gray-600">Filtrar por módulo</label>
+              <select
+                value={filters.module ?? ""}
+                onChange={event =>
+                  setFilters(prev => ({ ...prev, module: event.target.value || undefined, page: 0 }))
+                }
+                className="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+              >
+                <option value="">Todos</option>
+                {auditModules.map(module => (
+                  <option key={module.value} value={module.value}>
+                    {module.label}
+                  </option>
+                ))}
+              </select>
             </div>
-            {lastEvent.blockchainHash && (
-              <span className="rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-600">Blockchain</span>
-            )}
+            <div className="flex flex-col text-sm">
+              <label className="text-xs font-semibold text-gray-600">Filtrar por tipo</label>
+              <input
+                list="audit-event-types"
+                value={filters.eventType ?? ""}
+                onChange={event =>
+                  setFilters(prev => ({ ...prev, eventType: event.target.value || undefined, page: 0 }))
+                }
+                className="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+                placeholder="Qualquer tipo"
+              />
+            </div>
+            <div className="flex flex-col text-sm">
+              <label className="text-xs font-semibold text-gray-600">Busca</label>
+              <input
+                value={searchTerm}
+                onChange={event => setSearchTerm(event.target.value)}
+                className="mt-1 w-48 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+                placeholder="Usuário, hash, referência..."
+              />
+            </div>
           </div>
-          <div className="rounded-md border border-gray-100 bg-gray-50 p-3 text-sm text-gray-700">
-            <p>Ação: <span className="font-semibold">{lastEvent.action}</span></p>
-            {lastEvent.referenceId && <p>Referência: {lastEvent.referenceId}</p>}
-            {lastEvent.blockchainHash && <p>Hash: {lastEvent.blockchainHash}</p>}
+          <div className="flex items-center gap-2 text-sm">
+            <label className="text-xs font-semibold text-gray-600">Ordenar por</label>
+            <select
+              value={sortField}
+              onChange={event => setSortField(event.target.value as typeof sortField)}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+            >
+              <option value="occurredAt">Ocorrência</option>
+              <option value="eventType">Tipo</option>
+              <option value="module">Módulo</option>
+              <option value="username">Usuário</option>
+            </select>
+            <button
+              type="button"
+              onClick={() => setSortDirection(prev => (prev === "asc" ? "desc" : "asc"))}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100"
+            >
+              {sortDirection === "asc" ? "Asc" : "Desc"}
+            </button>
           </div>
-          {lastEvent.metadata && (
-            <pre className="overflow-auto rounded-lg bg-gray-900 p-4 text-sm text-orange-100">
-              {JSON.stringify(lastEvent.metadata, null, 2)}
-            </pre>
+        </div>
+
+        <div className="overflow-x-auto">
+          {eventsQuery.isLoading ? (
+            <div className="flex h-48 items-center justify-center">
+              <div className="h-10 w-10 animate-spin rounded-full border-4 border-orangeWheel-500 border-t-transparent" />
+            </div>
+          ) : sortedEvents.length === 0 ? (
+            <div className="rounded-md border border-dashed border-gray-300 p-6 text-center text-sm text-gray-500">
+              Nenhum evento encontrado para os filtros informados.
+            </div>
+          ) : (
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="px-3 py-2">Ocorrência</th>
+                  <th className="px-3 py-2">Tipo</th>
+                  <th className="px-3 py-2">Módulo</th>
+                  <th className="px-3 py-2">Operação</th>
+                  <th className="px-3 py-2">Usuário</th>
+                  <th className="px-3 py-2">Hash</th>
+                  <th className="px-3 py-2">Detalhes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {sortedEvents.map(event => (
+                  <tr key={event.id} className="align-top">
+                    <td className="px-3 py-3 text-xs text-gray-500">
+                      <div className="font-semibold text-gray-800">
+                        {new Date(event.occurredAt).toLocaleString("pt-BR")}
+                      </div>
+                      <div className="text-[10px] text-gray-400">
+                        Registrado em {new Date(event.createdAt).toLocaleString("pt-BR")}
+                      </div>
+                    </td>
+                    <td className="px-3 py-3 text-xs font-semibold text-gray-800">{event.eventType}</td>
+                    <td className="px-3 py-3 text-xs text-gray-600">{event.module}</td>
+                    <td className="px-3 py-3 text-xs text-gray-600">{event.operation}</td>
+                    <td className="px-3 py-3 text-xs text-gray-600">
+                      <div className="font-semibold text-gray-800">{event.username}</div>
+                      <div className="text-[10px] uppercase text-gray-400">{event.role}</div>
+                    </td>
+                    <td className="px-3 py-3 text-xs text-gray-600">
+                      {event.blockchainHash ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (navigator?.clipboard?.writeText) {
+                              void navigator.clipboard.writeText(event.blockchainHash);
+                            }
+                          }}
+                          className="break-all text-left font-mono text-[11px] text-orangeWheel-600 hover:underline"
+                          title="Clique para copiar"
+                        >
+                          {event.blockchainHash}
+                        </button>
+                      ) : (
+                        <span className="text-gray-400">—</span>
+                      )}
+                      {event.previousHash && (
+                        <div className="mt-1 text-[10px] text-gray-400">Prev: {event.previousHash}</div>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-xs text-gray-600">
+                      {event.referenceId && <div>Ref: {event.referenceId}</div>}
+                      {event.metadata && (
+                        <pre className="mt-1 max-h-24 overflow-auto rounded bg-gray-900 p-2 font-mono text-[10px] text-orange-100">
+                          {JSON.stringify(event.metadata, null, 2)}
+                        </pre>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           )}
-        </section>
-      )}
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-gray-200 pt-3 text-sm text-gray-600 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2">
+            <span>Página {currentPage + 1}</span>
+            <span className="text-gray-400">de {Math.max(totalPages, 1)}</span>
+            <select
+              value={filters.size ?? 10}
+              onChange={event =>
+                setFilters(prev => ({ ...prev, size: Number(event.target.value), page: 0 }))
+              }
+              className="rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-orangeWheel-500 focus:outline-none focus:ring-2 focus:ring-orangeWheel-200"
+            >
+              {[10, 20, 50].map(size => (
+                <option key={size} value={size}>
+                  {size} por página
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setFilters(prev => ({ ...prev, page: Math.max((prev.page ?? 0) - 1, 0) }))}
+              disabled={currentPage <= 0}
+              className="rounded-md border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Anterior
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setFilters(prev => ({
+                  ...prev,
+                  page: Math.min((prev.page ?? 0) + 1, Math.max(totalPages - 1, 0)),
+                }))
+              }
+              disabled={currentPage >= totalPages - 1}
+              className="rounded-md border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Próxima
+            </button>
+          </div>
+        </div>
+      </section>
     </div>
+  );
+}
+
+function AuditEventPreview({ event }: { event: AuditEventResponse }) {
+  return (
+    <section className="space-y-3 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-800">Evento registrado</h2>
+          <p className="text-xs text-gray-500">{new Date(event.createdAt).toLocaleString("pt-BR")}</p>
+        </div>
+        {event.blockchainHash && (
+          <span className="rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-600">Blockchain</span>
+        )}
+      </div>
+      <div className="rounded-md border border-gray-100 bg-gray-50 p-3 text-sm text-gray-700">
+        <p>
+          Tipo: <span className="font-semibold">{event.eventType}</span>
+        </p>
+        <p>
+          Operação: <span className="font-semibold">{event.operation}</span>
+        </p>
+        <p>
+          Usuário: <span className="font-semibold">{event.username}</span> ({event.role})
+        </p>
+        {event.referenceId && <p>Referência: {event.referenceId}</p>}
+        {event.blockchainHash && <p>Hash: {event.blockchainHash}</p>}
+      </div>
+      {event.metadata && (
+        <pre className="overflow-auto rounded-lg bg-gray-900 p-4 text-sm text-orange-100">
+          {JSON.stringify(event.metadata, null, 2)}
+        </pre>
+      )}
+    </section>
   );
 }

--- a/src/modules/audit/services/api.ts
+++ b/src/modules/audit/services/api.ts
@@ -1,6 +1,13 @@
 import api from "../../../shared/services/axios";
-import type { AuditEventRequest, AuditEventResponse } from "../types/audit";
+import type { AuditEventFilters, AuditEventPage, AuditEventRequest, AuditEventResponse } from "../types/audit";
 
 export const auditApi = {
-  createEvent: (payload: AuditEventRequest) => api.post<AuditEventResponse>("/audit/event", payload),
+  createEvent: async (payload: AuditEventRequest): Promise<AuditEventResponse> => {
+    const response = await api.post<AuditEventResponse>("/audit/event", payload);
+    return response.data;
+  },
+  listEvents: async (params?: AuditEventFilters): Promise<AuditEventPage> => {
+    const response = await api.get<AuditEventPage>("/audit/events", { params });
+    return response.data;
+  },
 };

--- a/src/modules/audit/types/audit.ts
+++ b/src/modules/audit/types/audit.ts
@@ -1,14 +1,55 @@
+export type AuditModule =
+  | 'INVENTORY'
+  | 'SERVICE_ORDER'
+  | 'CUSTOMER'
+  | 'OPERATIONS'
+  | 'SUPPLIER'
+  | 'ANALYTICS'
+  | 'AUDIT'
+
 export interface AuditEventRequest {
-  action: string
+  eventType: string
+  operation: string
+  module: AuditModule | string
+  username: string
+  role: string
+  occurredAt: string
   referenceId?: string
   metadata?: Record<string, unknown>
 }
 
 export interface AuditEventResponse {
   id: string
-  action: string
+  eventType: string
+  operation: string
+  module: AuditModule | string
+  username: string
+  role: string
+  occurredAt: string
   createdAt: string
   referenceId?: string
   metadata?: Record<string, unknown>
   blockchainHash?: string
+  previousHash?: string
+  signature?: string
+}
+
+export interface AuditEventPage {
+  content: AuditEventResponse[]
+  totalElements: number
+  totalPages: number
+  size: number
+  number: number
+}
+
+export interface AuditEventFilters {
+  page?: number
+  size?: number
+  eventType?: string
+  operation?: string
+  module?: string
+  username?: string
+  sort?: string
+  from?: string
+  to?: string
 }

--- a/src/modules/inventory/components/InventoryDashboard.tsx
+++ b/src/modules/inventory/components/InventoryDashboard.tsx
@@ -15,7 +15,7 @@ import type {
   InventoryRecommendation,
   RecommendationPipeline,
 } from "../types/inventory";
-import { InventoryItemModal, type InventoryItemFormValues } from "./InventoryItemModal";
+import { InventoryItemModal } from "./InventoryItemModal";
 
 const tabs = [
   { id: "items", label: "Itens" },
@@ -78,10 +78,13 @@ function InventoryDashboardContent() {
   const [historyIds, setHistoryIds] = useState<{ vehicleId?: number; clientId?: number }>({});
   const [historyData, setHistoryData] = useState<HistoryState>({});
 
-  const { data: items = [], isLoading: isLoadingItems, error: itemsError } = useQuery<InventoryItem[]>({
+  const itemsQuery = useQuery<InventoryItem[]>({
     queryKey: ["inventory", "items"],
-    queryFn: inventoryApi.getItems,
+    queryFn: () => inventoryApi.getItems(),
   });
+  const items = itemsQuery.data ?? [];
+  const isLoadingItems = itemsQuery.isLoading;
+  const itemsError = itemsQuery.error;
 
   const createItemMutation = useMutation({
     mutationFn: (payload: InventoryItemCreateDTO) => inventoryApi.createItem(payload),
@@ -110,26 +113,33 @@ function InventoryDashboardContent() {
   const cancelReservationMutation = useMutation({ mutationFn: inventoryApi.cancelReservation });
   const returnMutation = useMutation({ mutationFn: inventoryApi.registerReturn });
 
-  const { data: movements = [], refetch: refetchMovements, isFetching: isFetchingMovements } = useQuery<InventoryMovement[]>({
+  const movementsQuery = useQuery<InventoryMovement[]>({
     queryKey: ["inventory", "movements", movementFilters],
     queryFn: () => inventoryApi.listMovements(movementFilters),
   });
+  const movements = movementsQuery.data ?? [];
+  const refetchMovements = movementsQuery.refetch;
+  const isFetchingMovements = movementsQuery.isFetching;
 
-  const { data: pipelines = [] } = useQuery<RecommendationPipeline[]>({
+  const pipelinesQuery = useQuery<RecommendationPipeline[]>({
     queryKey: ["inventory", "pipelines"],
-    queryFn: inventoryApi.getRecommendationPipelines,
+    queryFn: () => inventoryApi.getRecommendationPipelines(),
   });
+  const pipelines = pipelinesQuery.data ?? [];
 
-  const { data: recommendations = [], refetch: refetchRecommendations, isFetching: isFetchingRecommendations } =
-    useQuery<InventoryRecommendation[]>({
-      queryKey: ["inventory", "recommendations", recommendationFilters],
-      queryFn: () => inventoryApi.getRecommendations(recommendationFilters),
-    });
+  const recommendationsQuery = useQuery<InventoryRecommendation[]>({
+    queryKey: ["inventory", "recommendations", recommendationFilters],
+    queryFn: () => inventoryApi.getRecommendations(recommendationFilters),
+  });
+  const recommendations = recommendationsQuery.data ?? [];
+  const refetchRecommendations = recommendationsQuery.refetch;
+  const isFetchingRecommendations = recommendationsQuery.isFetching;
 
-  const { data: criticalParts = [] } = useQuery<CriticalPartReport[]>({
+  const criticalPartsQuery = useQuery<CriticalPartReport[]>({
     queryKey: ["inventory", "criticalParts"],
-    queryFn: inventoryApi.getCriticalPartsReport,
+    queryFn: () => inventoryApi.getCriticalPartsReport(),
   });
+  const criticalParts = criticalPartsQuery.data ?? [];
 
   const filteredItems = useMemo(() => {
     if (!search.trim()) {

--- a/src/modules/inventory/types/inventory.ts
+++ b/src/modules/inventory/types/inventory.ts
@@ -1,7 +1,16 @@
+export interface InventoryPartSummary {
+  id: number
+  code?: string | null
+  name: string
+  manufacturer?: string | null
+  category?: string | null
+}
+
 export interface InventoryItemResponse {
   id: number
-  partId: number
-  partName: string
+  part?: InventoryPartSummary | null
+  partId?: number
+  partName?: string
   availableQuantity?: number | null
   currentQuantity?: number | null
   reservedQuantity?: number | null
@@ -9,8 +18,10 @@ export interface InventoryItemResponse {
   minimumStock?: number | null
   location?: string | null
   averageCost?: number | null
-  cost?: number | null
+  unitCost?: number | null
+  salePrice?: number | null
   status?: string | null
+  createdAt?: string
   updatedAt?: string
 }
 
@@ -18,24 +29,63 @@ export interface InventoryItem {
   id: number
   partId: number
   partName: string
+  partCode?: string
+  manufacturer?: string
   availableQuantity: number
   reservedQuantity: number
   minimumQuantity: number
   location?: string
   averageCost?: number
+  salePrice?: number
   status?: string
+  createdAt?: string
   updatedAt?: string
 }
 
 export interface InventoryItemCreateDTO {
   partId: number
-  availableQuantity: number
   minimumQuantity: number
+  initialQuantity: number
   location?: string
   averageCost?: number
+  salePrice?: number
 }
 
-export interface InventoryItemUpdateDTO extends Partial<InventoryItemCreateDTO> {}
+export interface InventoryItemUpdateDTO extends Partial<Omit<InventoryItemCreateDTO, 'initialQuantity' | 'partId'>> {
+  status?: string
+}
+
+export interface InventoryEntryRequest {
+  itemId?: number
+  partId?: number
+  quantity: number
+  unitCost?: number
+  unitPrice?: number
+  notes?: string
+}
+
+export interface StockReservationRequest {
+  serviceOrderItemId: number
+  quantity: number
+  notes?: string
+}
+
+export interface StockConsumptionRequest {
+  reservationId: number
+  quantity: number
+  notes?: string
+}
+
+export interface StockCancellationRequest {
+  reservationId: number
+  reason?: string
+}
+
+export interface StockReturnRequest {
+  serviceOrderItemId: number
+  quantity: number
+  notes?: string
+}
 
 export interface InventoryMovementResponse {
   id: number
@@ -44,12 +94,20 @@ export interface InventoryMovementResponse {
   quantity: number
   createdAt?: string
   occurredAt?: string
+  itemId?: number
+  inventoryItemId?: number
+  part?: InventoryPartSummary | null
   partId?: number
   partName?: string
   serviceOrderId?: number
+  serviceOrderItemId?: number
   vehicleId?: number
   notes?: string
   reservationId?: number
+  unitCost?: number | null
+  unitPrice?: number | null
+  balanceAfter?: number | null
+  performedBy?: string | null
 }
 
 export interface InventoryMovement {
@@ -60,15 +118,34 @@ export interface InventoryMovement {
   partId?: number
   partName?: string
   serviceOrderId?: number
+  serviceOrderItemId?: number
   vehicleId?: number
   notes?: string
   reservationId?: number
+  unitCost?: number
+  unitPrice?: number
+  balanceAfter?: number
+  performedBy?: string
 }
 
 export interface InventoryMovementFilters {
+  itemId?: number
   partId?: number
   serviceOrderId?: number
   vehicleId?: number
+}
+
+export interface InventoryRecommendationResponse {
+  id: string
+  part?: InventoryPartSummary | null
+  partId?: number
+  partName?: string
+  description?: string
+  priorityScore?: number
+  suggestedQuantity?: number
+  confidence?: number | null
+  rationale?: string | null
+  fallback?: boolean | null
 }
 
 export interface InventoryRecommendation {
@@ -78,6 +155,29 @@ export interface InventoryRecommendation {
   description?: string
   priorityScore?: number
   suggestedQuantity?: number
+  confidence?: number
+  rationale?: string
+  isFallback?: boolean
+}
+
+export interface CriticalPartReportResponse {
+  partId: number
+  partName: string
+  currentQuantity: number
+  minimumQuantity: number
+  recommendedAction?: string | null
+  severity: 'CRITICAL' | 'WARNING' | 'STABLE'
+  confidence?: number | null
+}
+
+export interface CriticalPartReport {
+  partId: number
+  partName: string
+  currentQuantity: number
+  minimumQuantity: number
+  recommendedAction?: string
+  severity: 'CRITICAL' | 'WARNING' | 'STABLE'
+  confidence?: number
 }
 
 export interface InventoryAvailabilityResponse {
@@ -86,6 +186,8 @@ export interface InventoryAvailabilityResponse {
   reserved?: number | null
   pending?: number | null
   breakdown?: Array<{ location: string; available: number }>
+  projectedStockoutDate?: string | null
+  coverageDays?: number | null
 }
 
 export interface InventoryAvailability {
@@ -93,6 +195,8 @@ export interface InventoryAvailability {
   reserved: number
   pending: number
   breakdown?: Array<{ location: string; available: number }>
+  projectedStockoutDate?: string
+  coverageDays?: number
 }
 
 export interface InventoryHistoryEntryResponse {
@@ -103,6 +207,7 @@ export interface InventoryHistoryEntryResponse {
   movementType: string
   partName?: string
   notes?: string
+  performedBy?: string | null
 }
 
 export interface InventoryHistoryEntry {
@@ -112,6 +217,7 @@ export interface InventoryHistoryEntry {
   movementType: string
   partName?: string
   notes?: string
+  performedBy?: string
 }
 
 export interface RecommendationPipeline {
@@ -119,35 +225,48 @@ export interface RecommendationPipeline {
   name: string
   description?: string
   updatedAt?: string
+  isDefault?: boolean
 }
 
 export function normalizeInventoryItem(item: InventoryItemResponse): InventoryItem {
+  const partId = item.part?.id ?? item.partId ?? 0
   return {
     id: item.id,
-    partId: item.partId,
-    partName: item.partName,
+    partId,
+    partName: item.part?.name ?? item.partName ?? `Peça ${partId}`,
+    partCode: item.part?.code ?? undefined,
+    manufacturer: item.part?.manufacturer ?? undefined,
     availableQuantity: item.availableQuantity ?? item.currentQuantity ?? 0,
     reservedQuantity: item.reservedQuantity ?? 0,
     minimumQuantity: item.minimumQuantity ?? item.minimumStock ?? 0,
     location: item.location ?? undefined,
-    averageCost: item.averageCost ?? item.cost ?? undefined,
+    averageCost: item.averageCost ?? item.unitCost ?? undefined,
+    salePrice: item.salePrice ?? undefined,
     status: item.status ?? undefined,
+    createdAt: item.createdAt,
     updatedAt: item.updatedAt,
   }
 }
 
 export function normalizeInventoryMovement(movement: InventoryMovementResponse): InventoryMovement {
+  const occurredAt = movement.occurredAt ?? movement.createdAt ?? new Date().toISOString()
+
   return {
     id: movement.id,
     movementType: movement.movementType ?? movement.type ?? 'UNKNOWN',
     quantity: movement.quantity,
-    occurredAt: movement.occurredAt ?? movement.createdAt ?? new Date().toISOString(),
-    partId: movement.partId,
-    partName: movement.partName,
+    occurredAt,
+    partId: movement.part?.id ?? movement.partId,
+    partName: movement.part?.name ?? movement.partName,
     serviceOrderId: movement.serviceOrderId,
+    serviceOrderItemId: movement.serviceOrderItemId,
     vehicleId: movement.vehicleId,
-    notes: movement.notes,
+    notes: movement.notes ?? undefined,
     reservationId: movement.reservationId,
+    unitCost: movement.unitCost ?? undefined,
+    unitPrice: movement.unitPrice ?? undefined,
+    balanceAfter: movement.balanceAfter ?? undefined,
+    performedBy: movement.performedBy ?? undefined,
   }
 }
 
@@ -159,6 +278,8 @@ export function normalizeInventoryAvailability(
     reserved: availability.reserved ?? 0,
     pending: availability.pending ?? 0,
     breakdown: availability.breakdown,
+    projectedStockoutDate: availability.projectedStockoutDate ?? undefined,
+    coverageDays: availability.coverageDays ?? undefined,
   }
 }
 
@@ -172,5 +293,34 @@ export function normalizeInventoryHistoryEntry(
     movementType: entry.movementType,
     partName: entry.partName,
     notes: entry.notes,
+    performedBy: entry.performedBy ?? undefined,
+  }
+}
+
+export function normalizeInventoryRecommendation(
+  recommendation: InventoryRecommendationResponse,
+): InventoryRecommendation {
+  return {
+    id: recommendation.id,
+    partId: recommendation.part?.id ?? recommendation.partId,
+    partName: recommendation.part?.name ?? recommendation.partName,
+    description: recommendation.description,
+    priorityScore: recommendation.priorityScore,
+    suggestedQuantity: recommendation.suggestedQuantity,
+    confidence: recommendation.confidence ?? undefined,
+    rationale: recommendation.rationale ?? undefined,
+    isFallback: recommendation.fallback ?? undefined,
+  }
+}
+
+export function normalizeCriticalPartReport(report: CriticalPartReportResponse): CriticalPartReport {
+  return {
+    partId: report.partId,
+    partName: report.partName,
+    currentQuantity: report.currentQuantity,
+    minimumQuantity: report.minimumQuantity,
+    recommendedAction: report.recommendedAction ?? undefined,
+    severity: report.severity,
+    confidence: report.confidence ?? undefined,
   }
 }

--- a/src/shared/components/HttpStatusBanner.tsx
+++ b/src/shared/components/HttpStatusBanner.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  subscribeHttpStatusEvent,
+  type HttpStatusEventDetail,
+  type HttpStatusEventType,
+} from '../services/httpEvents'
+
+interface HttpBannerEvent extends HttpStatusEventDetail {
+  type: HttpStatusEventType
+}
+
+const DISPLAY_DURATION_MS = 6000
+
+export function HttpStatusBanner() {
+  const [event, setEvent] = useState<HttpBannerEvent | null>(null)
+
+  useEffect(() => {
+    const unsubscribeUnauthorized = subscribeHttpStatusEvent('unauthorized', detail => {
+      setEvent({ ...detail, type: 'unauthorized' })
+    })
+    const unsubscribeForbidden = subscribeHttpStatusEvent('forbidden', detail => {
+      setEvent({ ...detail, type: 'forbidden' })
+    })
+
+    return () => {
+      unsubscribeUnauthorized()
+      unsubscribeForbidden()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!event) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setEvent(current => (current?.timestamp === event.timestamp ? null : current))
+    }, DISPLAY_DURATION_MS)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [event])
+
+  const accentStyles = useMemo(() => {
+    if (!event) {
+      return 'bg-gray-900 text-white border-gray-700'
+    }
+
+    return event.type === 'unauthorized'
+      ? 'bg-red-600 text-white border-red-700'
+      : 'bg-amber-500 text-gray-900 border-amber-600'
+  }, [event])
+
+  if (!event) {
+    return null
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-2 z-[1000] flex justify-center px-4">
+      <div
+        role="status"
+        className={`pointer-events-auto flex max-w-3xl flex-1 items-start gap-3 rounded-lg border px-4 py-3 shadow-lg transition-all ${accentStyles}`}
+      >
+        <span aria-hidden className="mt-1 text-lg">
+          {event.type === 'unauthorized' ? '🔒' : '🚫'}
+        </span>
+        <div className="flex-1 text-sm">
+          <p className="font-semibold">
+            {event.type === 'unauthorized' ? 'Sessão expirada' : 'Acesso negado'}
+          </p>
+          <p className="mt-1 opacity-90">{event.message}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setEvent(null)}
+          className="rounded-md p-1 text-sm font-medium transition hover:bg-black/10"
+        >
+          Fechar
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/shared/components/Layout.tsx
+++ b/src/shared/components/Layout.tsx
@@ -5,6 +5,7 @@ import ProtectedRoute from '../../modules/auth/components/ProtectedRoute'
 import { useAuth } from '../../modules/auth/hooks/useAuth'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import Sidebar from './Sidebar'
+import { HttpStatusBanner } from './HttpStatusBanner'
 
 const ChatBot = lazy(() => import('../../modules/ai/components/ChatBot/ChatBot'))
 
@@ -44,6 +45,7 @@ export function Layout() {
   return (
     <ProtectedRoute>
       <div className={containerClassName}>
+        <HttpStatusBanner />
         {shouldShowChatBot && (
           <Suspense fallback={null}>
             <ChatBot />

--- a/src/shared/services/httpEvents.ts
+++ b/src/shared/services/httpEvents.ts
@@ -1,0 +1,33 @@
+export type HttpStatusEventType = 'unauthorized' | 'forbidden'
+
+export interface HttpStatusEventDetail {
+  status: number
+  message?: string
+  timestamp: number
+}
+
+type HttpStatusListener = (detail: HttpStatusEventDetail) => void
+
+const listeners: Record<HttpStatusEventType, Set<HttpStatusListener>> = {
+  unauthorized: new Set(),
+  forbidden: new Set(),
+}
+
+export function emitHttpStatusEvent(type: HttpStatusEventType, detail: Omit<HttpStatusEventDetail, 'timestamp'>) {
+  const payload: HttpStatusEventDetail = { ...detail, timestamp: Date.now() }
+
+  for (const listener of listeners[type]) {
+    try {
+      listener(payload)
+    } catch (error) {
+      console.error('Erro ao notificar listener HTTP', error)
+    }
+  }
+}
+
+export function subscribeHttpStatusEvent(type: HttpStatusEventType, listener: HttpStatusListener) {
+  listeners[type].add(listener)
+  return () => {
+    listeners[type].delete(listener)
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared HTTP status emitter/banner so 401/403 responses refresh tokens and display access feedback
- align the inventory module with the backend DTOs, expanding item/movement APIs, validation, and UI indicators for recommendations and reports
- overhaul the audit and analytics dashboards to call the new endpoints, exposing role-limited event logging, pagination with blockchain hashes, and backend-driven insights

## Testing
- yarn lint *(fails: workspace is not in the lockfile; needs yarn install)*

------
https://chatgpt.com/codex/tasks/task_e_690c0c3c86e88331a806e75970d1b781